### PR TITLE
Feat/nuitka 1

### DIFF
--- a/.github/workflows/nuitka.yml
+++ b/.github/workflows/nuitka.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Install Linux-specific Dependencies
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: |
-          apt-get update
-          apt-get install -y mold clang
+          sudo apt-get update
+          sudo apt-get install -y mold clang
 
       - name: Install Dependencies
         run: pip install -r requirements.txt

--- a/.github/workflows/nuitka.yml
+++ b/.github/workflows/nuitka.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5.3.0
         with:
+          python-version: '3.13'
           architecture: ${{ matrix.arch }}
           cache: 'pip'
           cache-dependency-path: |
@@ -45,7 +46,6 @@ jobs:
           include-data-files: LICENSE=LICENSE
           disable-console: false
           product-name: CIMS-backend
-          file-version: rolling
           mingw64: on
       - name: Build (Linux)
         if: ${{ startsWith(matrix.os, 'ubuntu') }}

--- a/.github/workflows/nuitka.yml
+++ b/.github/workflows/nuitka.yml
@@ -62,5 +62,5 @@ jobs:
       - name: Upload unsigned application
         uses: actions/upload-artifact@v4.4.2
         with:
-          name: ${{ matrix.os }}-${{ matrix.arch }}
+          name: ${{ matrix.os }}
           path: build/CIMS.dist

--- a/.github/workflows/nuitka.yml
+++ b/.github/workflows/nuitka.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           mode: standalone
           script-name: CIMS.py
-          output-file: ClassWidgets
+          output-file: CIMS-backend
 
       - name: Upload unsigned application
         uses: actions/upload-artifact@v4.4.2

--- a/.github/workflows/nuitka.yml
+++ b/.github/workflows/nuitka.yml
@@ -2,9 +2,11 @@ on:
   push: 
     branches:
       - main
+      - nuitka-1
   pull_request: 
     branches:
       - main
+      - nuitka-1
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/nuitka.yml
+++ b/.github/workflows/nuitka.yml
@@ -46,7 +46,6 @@ jobs:
           disable-console: false
           file-version: 1.0.0.0
           product-name: CIMS-backend
-          mingw64: on
       - name: Build (Linux)
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
         uses: Nuitka/Nuitka-Action@main

--- a/.github/workflows/nuitka.yml
+++ b/.github/workflows/nuitka.yml
@@ -23,7 +23,6 @@ jobs:
         uses: actions/setup-python@v5.3.0
         with:
           python-version: '3.13'
-          architecture: ${{ matrix.arch }}
           cache: 'pip'
           cache-dependency-path: |
             **/requirements*.txt

--- a/.github/workflows/nuitka.yml
+++ b/.github/workflows/nuitka.yml
@@ -44,6 +44,7 @@ jobs:
           output-file: CIMS-backend
           include-data-files: LICENSE=LICENSE
           disable-console: false
+          file-version: 1.0.0.0
           product-name: CIMS-backend
           mingw64: on
       - name: Build (Linux)

--- a/.github/workflows/nuitka.yml
+++ b/.github/workflows/nuitka.yml
@@ -1,0 +1,64 @@
+on:
+  push: 
+    branches:
+      - main
+  pull_request: 
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  builder_matrix:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.2.2
+      - name: Setup Python
+        uses: actions/setup-python@v5.3.0
+        with:
+          architecture: ${{ matrix.arch }}
+          cache: 'pip'
+          cache-dependency-path: |
+            **/requirements*.txt
+      - name: Install Linux-specific Dependencies
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        run: |
+          apt-get update
+          apt-get install -y mold clang
+
+      - name: Install Dependencies
+        run: pip install -r requirements.txt
+
+      - name: Build (Windows)
+        if: ${{ startsWith(matrix.os, 'windows') }}
+        uses: Nuitka/Nuitka-Action@main
+        with:
+          mode: standalone
+          script-name: CIMS.py
+          output-file: CIMS-backend
+          include-data-files: LICENSE=LICENSE
+          disable-console: false
+          product-name: CIMS-backend
+          file-version: rolling
+          mingw64: on
+      - name: Build (Linux)
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        uses: Nuitka/Nuitka-Action@main
+        env:
+          CC: clang
+          CXX: clang++
+          LDFLAGS: "-fuse-ld=mold"
+        with:
+          mode: standalone
+          script-name: CIMS.py
+          output-file: ClassWidgets
+
+      - name: Upload unsigned application
+        uses: actions/upload-artifact@v4.4.2
+        with:
+          name: ${{ matrix.os }}-${{ matrix.arch }}
+          path: build/CIMS.dist


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

添加一个新的 CI 工作流程，使用 Nuitka 构建 Linux 和 Windows 的独立可执行文件。

CI：
- 添加一个新的 CI 工作流程，使用 Nuitka 构建 Linux 和 Windows 的独立可执行文件。
- 该工作流程在推送到 main 和 nuitka-1 分支时，以及在向这些分支发起 pull request 时触发。
- 该工作流程使用构建矩阵来为 Ubuntu 和 Windows 构建。
- 该工作流程将构建的可执行文件作为 artifacts 上传。

<details>
<summary>Original summary in English</summary>

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

添加一个新的 CI 工作流程，以使用 Nuitka 构建 Linux 和 Windows 的独立可执行文件。

CI：
- 添加一个新的 CI 工作流程，该工作流程使用 Nuitka 构建 Linux 和 Windows 的独立可执行文件。
- 该工作流程在推送到 main 和 nuitka-1 分支时，以及在向这些分支的 pull request 上触发。
- 该工作流程使用构建矩阵为 Ubuntu 和 Windows 构建。
- 该工作流程将构建的可执行文件作为 artifacts 上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adds a new CI workflow to build standalone executables for Linux and Windows using Nuitka.

CI:
- Adds a new CI workflow that builds standalone executables for Linux and Windows using Nuitka.
- The workflow is triggered on pushes to the main and nuitka-1 branches, and on pull requests to those branches.
- The workflow uses a build matrix to build for Ubuntu and Windows.
- The workflow uploads the built executables as artifacts.

</details>

</details>